### PR TITLE
Use BufReader for file reading ops

### DIFF
--- a/src/tar.rs
+++ b/src/tar.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fs;
 use std::fs::File;
 use std::fs::Metadata;
-use std::io::{Error, ErrorKind};
+use std::io::{BufReader, Error, ErrorKind};
 use std::os::unix::prelude::FileTypeExt;
 use std::str;
 use std::string::String;
@@ -193,9 +193,10 @@ impl TarNode {
         }
 
         let mut file = File::open(&filename)?;
+        let mut reader = BufReader::new(file);
         Ok(TarNode {
             header,
-            data: TarNode::chunk_file(&mut file, None)?,
+            data: TarNode::chunk_file(&mut reader, None)?,
         })
     }
 
@@ -310,11 +311,12 @@ impl TarFile {
     /// ```
     pub fn open(filename: String) -> Result<Self, Error> {
         let file = File::open(&filename).unwrap();
+        let mut reader = BufReader::new(file);
         let mut out = TarFile {
             file: Vec::<TarNode>::new(),
         };
 
-        while let Ok(t) = TarNode::read(&file) {
+        while let Ok(t) = TarNode::read(&mut reader) {
             out.file.push(t);
         }
 


### PR DESCRIPTION
Use BufReader internally for all file reading. This gives a huge
performance boost when dealing with large reads. I created a
benchmarking binary for testing a tar archive with one 1GB file and these are
the results I get:
```
01                      time:   [569.08 ms 569.41 ms 569.74 ms]
                        change: [-62.216% -62.183% -62.151%] (p = 0.00 < 0.05)
                        Performance has improved.
```

See: https://doc.rust-lang.org/std/io/struct.BufReader.html