### PR TITLE
Move read buffer out of hotloop

### DIFF
--- a/src/tar.rs
+++ b/src/tar.rs
@@ -212,9 +212,9 @@ impl TarNode {
             usize::MAX
         };
 
+        /* Carve out 512 bytes at a time */
+        let mut buf: [u8; 512] = [0; 512];
         loop {
-            /* Carve out 512 bytes at a time */
-            let mut buf: [u8; 512] = [0; 512];
             let len = file.read(&mut buf).expect("Failed to read");
 
             n -= 1;


### PR DESCRIPTION
This gives the following performance boosts in my tests:
```
01                      time:   [528.26 ms 528.86 ms 529.48 ms]
                        change: [-2.6169% -2.4571% -2.3009%] (p = 0.00 < 0.05)
                        Performance has improved.
```